### PR TITLE
README.mdのCIバッジを更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ https://github.com/ruffpug/SuckerPuncherReimuSan
 
 https://ruffpug.github.io/SuckerPuncherReimuSan
 
-[![CI](https://github.com/ruffpug/SuckerPuncherReimuSan/actions/workflows/CI.yml/badge.svg?branch=master)](https://github.com/ruffpug/SuckerPuncherReimuSan/actions/workflows/CI.yml)
+[![CI](https://github.com/ruffpug/SuckerPuncherReimuSan/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/ruffpug/SuckerPuncherReimuSan/actions/workflows/CI.yml)
 ![Web](https://img.shields.io/static/v1?label=platform&message=Web&color=green)
 ![Kotlin](https://img.shields.io/static/v1?label=language&message=Kotlin&color=orange)
 


### PR DESCRIPTION
CIバッジのブランチ名が `master` ブランチになっていたため、`main` ブランチに変更した。